### PR TITLE
Configure JWT_SECRET generation and simplify IdP login redirect handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM nginx:stable-alpine AS deploy
 # Default Environment Variable values
 ENV API_HOST=localhost
 ENV API_PORT=8083
-ENV IDP_LOGIN_URI=/login
+ENV IDP_LOGIN_URI=http://localhost:8084/login
 
 # Copy built assets from build stage to nginx serving directory
 COPY --from=build /app/dist /usr/share/nginx/html

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
       RUNBOOKS_DIR: ./runbooks
       ENABLE_LOGIN: "true"
       LOGGING_LEVEL: "INFO"
+      JWT_SECRET: ${JWT_SECRET:-}
     working_dir: /opt/stage0/runner
     healthcheck:
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8083/metrics')"]
@@ -36,6 +37,7 @@ services:
     environment:
       API_HOST: api
       API_PORT: 8083
+      IDP_LOGIN_URI: http://localhost:8084/login
     depends_on:
       api:
         condition: service_healthy

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -56,7 +56,7 @@ server {
     }
 
     # IdP login redirect - static route that redirects to configured IdP
-    # Defaults to /login (internal route) if IDP_LOGIN_URI not set
+    # IDP_LOGIN_URI must be a full URI (e.g., http://localhost:8084/login or https://idp.example.com/login)
     location = /auth/login {
         return 302 ${IDP_LOGIN_URI}$is_args$args;
     }

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "IDP_LOGIN_URI=http://localhost:8084/login vite",
     "build": "vue-tsc && vite build",
     "preview": "vite preview",
     "pull": "docker compose --profile service pull",
-    "api": "docker compose --profile api up -d",
-    "service": "docker compose --profile service up -d && sleep 3 && npm run open",
+    "api": "bash -c 'export JWT_SECRET=$(date +%s) && docker compose --profile api up -d'",
+    "service": "bash -c 'export JWT_SECRET=$(date +%s) && docker compose --profile service up -d && sleep 3 && npm run open'",
     "down": "docker compose --profile api --profile service down",
     "container": "docker build -t ghcr.io/agile-learning-institute/stage0_runbook_spa:latest .",
     "open": "open -a 'Google Chrome' 'http://localhost:8084' || google-chrome 'http://localhost:8084' || xdg-open 'http://localhost:8084' || echo 'Could not open browser. Please navigate to http://localhost:8084'"

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -42,9 +42,8 @@ router.beforeEach((to, _from, next) => {
   
   // If route requires authentication and user is not authenticated, redirect to login
   if (to.meta.requiresAuth && !authStore.isAuthenticated) {
-    // Redirect to /auth/login - nginx will forward this to the configured IdP
-    // If IDP_LOGIN_URI is set to an external URL, nginx redirects there
-    // If IDP_LOGIN_URI is /login (default), nginx redirects to internal login page
+    // Redirect to /auth/login - nginx (production) or Vite middleware (dev) will forward this
+    // to the configured IdP based on IDP_LOGIN_URI env var (defaults to /login)
     // This ensures a single code path that works for both internal and external IdP
     const returnUrl = encodeURIComponent(window.location.origin + to.fullPath)
     window.location.href = `/auth/login?return_url=${returnUrl}`

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,58 @@
-import { defineConfig } from 'vite'
+import { defineConfig, Plugin } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { fileURLToPath, URL } from 'node:url'
 
+// Plugin to handle /auth/login redirect in dev mode
+const authLoginRedirectPlugin = (): Plugin => {
+  return {
+    name: 'auth-login-redirect',
+    enforce: 'pre', // Run before other plugins
+    configureServer(server) {
+      // Insert middleware at the beginning of the stack to ensure it runs first
+      const authLoginHandler = (req: any, res: any, next: any) => {
+        if (req.url && (req.url === '/auth/login' || req.url.startsWith('/auth/login?'))) {
+          // Get IDP_LOGIN_URI from env (should be full URI like http://localhost:8084/login)
+          const idpLoginUri = process.env.IDP_LOGIN_URI || 'http://localhost:8084/login'
+          // Extract query string from the request if present
+          const queryString = req.url.includes('?') ? req.url.split('?')[1] : ''
+          
+          // Parse the IDP_LOGIN_URI to extract the path for same-origin redirects
+          let redirectPath: string
+          try {
+            const url = new URL(idpLoginUri)
+            // If it's the same origin (localhost:8084), use relative path
+            const isSameOrigin = url.hostname === 'localhost' && (url.port === '8084' || (!url.port && server.config.server?.port === 8084))
+            if (isSameOrigin) {
+              redirectPath = url.pathname
+            } else {
+              // External URL - use full URI
+              redirectPath = idpLoginUri
+            }
+          } catch {
+            // If parsing fails, assume it's already a path
+            redirectPath = idpLoginUri
+          }
+          
+          // Construct redirect URL with query string
+          const hasQueryParams = redirectPath.includes('?')
+          const redirectUrl = queryString 
+            ? `${redirectPath}${hasQueryParams ? '&' : '?'}${queryString}`
+            : redirectPath
+          
+          res.writeHead(302, { Location: redirectUrl })
+          res.end()
+          return
+        }
+        next()
+      }
+      // Insert at the very beginning to ensure it runs before Vite's SPA fallback
+      server.middlewares.stack.unshift({ route: '', handle: authLoginHandler })
+    }
+  }
+}
+
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [vue(), authLoginRedirectPlugin()],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))


### PR DESCRIPTION
- Add JWT_SECRET generation to npm scripts (api, service) using date +%s
- Update docker-compose.yaml to pass JWT_SECRET and IDP_LOGIN_URI to containers
- Simplify nginx.conf.template to always use full URI for IDP_LOGIN_URI (no conditional logic)
- Add Vite plugin to handle /auth/login redirects in dev mode
- Update package.json dev script to set IDP_LOGIN_URI=http://localhost:8084/login
- Update Dockerfile default IDP_LOGIN_URI to full URI format
- All configurations now use full URIs for IDP_LOGIN_URI for consistency